### PR TITLE
CSCETSIN-107: Restructure consumer to enable running RabbitMQ as service

### DIFF
--- a/etsin_finder_search/rabbitmq/rabbitmq_client.py
+++ b/etsin_finder_search/rabbitmq/rabbitmq_client.py
@@ -77,10 +77,9 @@ class MetaxConsumer():
                 if reindex_success:
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                 else:
-                    log.info('Failed to reindex %s', json.loads(
+                    self.log.info('Failed to reindex %s', json.loads(
                         body).get('urn_identifier', 'unknown identifier'))
                     ch.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
-
 
         def callback_delete(ch, method, properties, body):
             delete_success = False
@@ -92,7 +91,7 @@ class MetaxConsumer():
                 if delete_success:
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                 else:
-                    log.info('Failed to delete %s', json.loads(
+                    self.log.info('Failed to delete %s', json.loads(
                         body).get('urn_identifier', 'unknown identifier'))
                     # TODO: If delete fails because there's no such id in index,
                     # no need to requeue
@@ -102,7 +101,6 @@ class MetaxConsumer():
         self.channel.basic_consume(callback_reindex, queue=queue_1)
         self.channel.basic_consume(callback_reindex, queue=queue_2)
         self.channel.basic_consume(callback_delete, queue=queue_3)
-
 
     def run(self):
         self.log.info('[*] RabbitMQ client started')

--- a/etsin_finder_search/rabbitmq/rabbitmq_client.py
+++ b/etsin_finder_search/rabbitmq/rabbitmq_client.py
@@ -15,99 +15,96 @@ Press CTRL+C to exit script.
 import json
 import pika
 
-from etsin_finder_search.catalog_record_converter import CRConverter
-from etsin_finder_search.elastic.service.es_service import ElasticSearchService
-
 from elasticsearch.exceptions import RequestError
 
+from etsin_finder_search.catalog_record_converter import CRConverter
+from etsin_finder_search.elastic.service.es_service import ElasticSearchService
+from etsin_finder_search.reindexing_log import get_logger
 from etsin_finder_search.utils import get_metax_rabbit_mq_config
 from etsin_finder_search.utils import get_elasticsearch_config
-from etsin_finder_search.reindexing_log import get_logger
 
-log = get_logger(__name__)
+class MetaxConsumer():
+    def __init__(self):
+        self.log = get_logger(__name__)
 
-# Get configs
-rabbit_settings = get_metax_rabbit_mq_config()
-es_settings = get_elasticsearch_config()
+        # Get configs
+        # If these raise errors, let consumer init fail
+        rabbit_settings = get_metax_rabbit_mq_config()
+        es_settings = get_elasticsearch_config()
 
-if not rabbit_settings or not es_settings:
-    quit()
+        # Set up RabbitMQ connection, channel, exchange and queues
+        credentials = pika.PlainCredentials(
+            rabbit_settings['USER'], rabbit_settings['PASSWORD'])
+        connection = pika.BlockingConnection(
+            pika.ConnectionParameters(
+                rabbit_settings['HOST'],
+                rabbit_settings['PORT'],
+                rabbit_settings['VHOST'],
+                credentials))
 
-# Set up RabbitMQ connection, channel, exchange and queues
-credentials = pika.PlainCredentials(
-    rabbit_settings['USER'], rabbit_settings['PASSWORD'])
-connection = pika.BlockingConnection(
-    pika.ConnectionParameters(
-        rabbit_settings['HOST'],
-        rabbit_settings['PORT'],
-        rabbit_settings['VHOST'],
-        credentials))
+        self.channel = connection.channel()
 
-channel = connection.channel()
+        exchange = rabbit_settings['EXCHANGE']
+        queue_1 = 'etsin-create'
+        queue_2 = 'etsin-update'
+        queue_3 = 'etsin-delete'
 
-exchange = rabbit_settings['EXCHANGE']
-queue_1 = 'etsin-create'
-queue_2 = 'etsin-update'
-queue_3 = 'etsin-delete'
+        self.channel.queue_declare(queue_1, durable=True)
+        self.channel.queue_declare(queue_2, durable=True)
+        self.channel.queue_declare(queue_3, durable=True)
 
-channel.queue_declare(queue_1, durable=True)
-channel.queue_declare(queue_2, durable=True)
-channel.queue_declare(queue_3, durable=True)
+        self.channel.queue_bind(exchange=exchange, queue=queue_1, routing_key='create')
+        self.channel.queue_bind(exchange=exchange, queue=queue_2, routing_key='update')
+        self.channel.queue_bind(exchange=exchange, queue=queue_3, routing_key='delete')
 
-channel.queue_bind(exchange=exchange, queue=queue_1, routing_key='create')
-channel.queue_bind(exchange=exchange, queue=queue_2, routing_key='update')
-channel.queue_bind(exchange=exchange, queue=queue_3, routing_key='delete')
+        # Set up ElasticSearch client
+        es_client = ElasticSearchService(es_settings)
+        if not es_client.index_exists():
+            if not es_client.create_index_and_mapping():
+                # If there's no ES index, don't create consumer
+                raise Exception
 
-# Set up ElasticSearch client
-es_client = ElasticSearchService(es_settings)
-if not es_client:
-    quit()
-if not es_client.index_exists():
-    if not es_client.create_index_and_mapping():
-        quit()
-
-
-def callback_reindex(ch, method, properties, body):
-    converter = CRConverter()
-    es_data_model = converter.convert_metax_catalog_record_json_to_es_data_model(
-        json.loads(body))
-    reindex_success = False
-    try:
-        reindex_success = es_client.reindex_dataset(es_data_model)
-    except RequestError:
-        reindex_success = False
-    finally:
-        if reindex_success:
-            channel.basic_ack(delivery_tag=method.delivery_tag)
-        else:
-            log.info('Failed to reindex %s', json.loads(
-                body).get('urn_identifier', 'unknown identifier'))
-            channel.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
+        def callback_reindex(ch, method, properties, body):
+            converter = CRConverter()
+            es_data_model = converter.convert_metax_catalog_record_json_to_es_data_model(
+                json.loads(body))
+            reindex_success = False
+            try:
+                reindex_success = es_client.reindex_dataset(es_data_model)
+            except RequestError:
+                reindex_success = False
+            finally:
+                if reindex_success:
+                    ch.basic_ack(delivery_tag=method.delivery_tag)
+                else:
+                    log.info('Failed to reindex %s', json.loads(
+                        body).get('urn_identifier', 'unknown identifier'))
+                    ch.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
 
 
-def callback_delete(ch, method, properties, body):
-    print('about to delete %s', json.loads(body).get('urn_identifier'))
-    delete_success = False
-    try:
-        delete_success = es_client.delete_dataset(json.loads(body).get('urn_identifier'))
-    except RequestError:
-        delete_success = False
-    finally:
-        if delete_success:
-            channel.basic_ack(delivery_tag=method.delivery_tag)
-        else:
-            log.info('Failed to delete %s', json.loads(
-                body).get('urn_identifier', 'unknown identifier'))
-            # TODO: If delete fails because there's no such id in index,
-            # no need to requeue
-            channel.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
+        def callback_delete(ch, method, properties, body):
+            delete_success = False
+            try:
+                delete_success = es_client.delete_dataset(json.loads(body).get('urn_identifier'))
+            except RequestError:
+                delete_success = False
+            finally:
+                if delete_success:
+                    ch.basic_ack(delivery_tag=method.delivery_tag)
+                else:
+                    log.info('Failed to delete %s', json.loads(
+                        body).get('urn_identifier', 'unknown identifier'))
+                    # TODO: If delete fails because there's no such id in index,
+                    # no need to requeue
+                    ch.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
+
+        # Set up consumer
+        self.channel.basic_consume(callback_reindex, queue=queue_1)
+        self.channel.basic_consume(callback_reindex, queue=queue_2)
+        self.channel.basic_consume(callback_delete, queue=queue_3)
 
 
-# Set up consumer
-channel.basic_consume(callback_reindex, queue=queue_1)
-channel.basic_consume(callback_reindex, queue=queue_2)
-channel.basic_consume(callback_delete, queue=queue_3)
-
-log.info('[*] RabbitMQ client started')
-print('[*] RabbitMQ is running. To exit press CTRL+C. See logs for indexing details.')
-channel.start_consuming()
+    def run(self):
+        self.log.info('[*] RabbitMQ client started')
+        print('[*] RabbitMQ is running. To exit press CTRL+C. See logs for indexing details.')
+        self.channel.start_consuming()

--- a/etsin_finder_search/reindexing_log.py
+++ b/etsin_finder_search/reindexing_log.py
@@ -6,10 +6,10 @@ from etsin_finder_search.utils import get_config_from_file, executing_travis
 def get_logger(logger_name):
     conf = get_config_from_file() if not executing_travis() else {}
     logger = logging.getLogger(logger_name if logger_name else 'etsin_finder_search')
+    logger.setLevel(conf.get('SEARCH_APP_LOG_LEVEL', 'DEBUG'))
     handler = logging.handlers.RotatingFileHandler(conf.get('SEARCH_APP_LOG_PATH',
                                                             '/var/log/etsin_finder_search/etsin_finder_search.log'),
                                                    maxBytes=10000000, mode='a', backupCount=30)
-    handler.setLevel(conf.get('SEARCH_APP_LOG_LEVEL', 'DEBUG'))
     formatter = logging.Formatter("[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/run_rabbitmq_consumer.py
+++ b/run_rabbitmq_consumer.py
@@ -1,1 +1,6 @@
-import etsin_finder_search.rabbitmq.rabbitmq_client
+#!/usr/bin/python
+
+from etsin_finder_search.rabbitmq.rabbitmq_client import MetaxConsumer
+
+consumer = MetaxConsumer()
+consumer.run()


### PR DESCRIPTION
Turn RabbitMQ script into a class so it can be run as service.
Note that you should have the newest version of etsin-ops (commit https://github.com/CSCfi/etsin-ops/commit/ad959c58f21dacf6e48e5c74e87fae6512fe5b18) when testing.