### PR TITLE
Enable stopping and starting of rabbitmq consumer service on elastics…

### DIFF
--- a/etsin_finder_search/catalog_record_converter.py
+++ b/etsin_finder_search/catalog_record_converter.py
@@ -7,6 +7,7 @@ log = get_logger(__name__)
 class CRConverter:
 
     def convert_metax_cr_urn_ids_to_es_data_model(self, urn_identifiers_in_metax, metax_api):
+        log.info("Converting {0} Metax catalog records to Elasticsearch documents..".format(len(urn_identifiers_in_metax)))
         es_dataset_data_models = []
         for urn_id_in_metax in urn_identifiers_in_metax:
             es_data_model = self._convert_metax_cr_urn_id_to_es_data_model(urn_id_in_metax, metax_api)

--- a/etsin_finder_search/elastic/service/es_service.py
+++ b/etsin_finder_search/elastic/service/es_service.py
@@ -24,7 +24,15 @@ class ElasticSearchService:
         self.es = Elasticsearch(es_config.get('HOSTS'), **self._get_connection_parameters(es_config))
 
     def client_ok(self):
-        return self.es
+        try:
+            is_ok = self.es and self.es.ping()
+        except Exception:
+            is_ok = False
+
+        if not is_ok:
+            log.error("Unable to connect to Elasticsearch instance")
+
+        return is_ok
 
     def index_exists(self):
         return self.es.indices.exists(index=self.INDEX_NAME)

--- a/etsin_finder_search/rabbitmq/rabbitmq_client.py
+++ b/etsin_finder_search/rabbitmq/rabbitmq_client.py
@@ -14,95 +14,185 @@ Press CTRL+C to exit script.
 
 import json
 import pika
+import time
 
 from elasticsearch.exceptions import RequestError
 
 from etsin_finder_search.catalog_record_converter import CRConverter
 from etsin_finder_search.elastic.service.es_service import ElasticSearchService
 from etsin_finder_search.reindexing_log import get_logger
-from etsin_finder_search.utils import get_metax_rabbit_mq_config
-from etsin_finder_search.utils import get_elasticsearch_config
+from etsin_finder_search.utils import get_metax_rabbit_mq_config, get_elasticsearch_config, get_config_from_file
+
 
 class MetaxConsumer():
+
     def __init__(self):
         self.log = get_logger(__name__)
+        self.indexing_operation_complete = True
+        self.init_ok = False
 
         # Get configs
         # If these raise errors, let consumer init fail
         rabbit_settings = get_metax_rabbit_mq_config()
         es_settings = get_elasticsearch_config()
 
+        if not rabbit_settings or not es_settings:
+            self.log.error("Unable to load RabbitMQ configuration or Elasticsearch configuration")
+            return
+
         # Set up RabbitMQ connection, channel, exchange and queues
         credentials = pika.PlainCredentials(
             rabbit_settings['USER'], rabbit_settings['PASSWORD'])
-        connection = pika.BlockingConnection(
-            pika.ConnectionParameters(
-                rabbit_settings['HOST'],
-                rabbit_settings['PORT'],
-                rabbit_settings['VHOST'],
-                credentials))
+
+        # Try connecting every one minute 30 times
+        try:
+            connection = pika.BlockingConnection(
+                pika.ConnectionParameters(
+                    rabbit_settings['HOST'],
+                    rabbit_settings['PORT'],
+                    rabbit_settings['VHOST'],
+                    credentials,
+                    connection_attempts=30,
+                    retry_delay=60))
+        except Exception as e:
+            self.log.error(e)
+            self.log.error("Unable to open RabbitMQ connection")
+            return
+
+        # Set up ElasticSearch client. In case connection cannot be established, try every 2 seconds for 30 seconds
+        es_conn_ok = False
+        i = 0
+        while not es_conn_ok and i < 15:
+            self.es_client = ElasticSearchService(es_settings)
+            if self.es_client.client_ok():
+                es_conn_ok = True
+            else:
+                time.sleep(2)
+                i += 1
+
+        if not es_conn_ok or not self._ensure_index_existence():
+            return
 
         self.channel = connection.channel()
+        self.exchange = rabbit_settings['EXCHANGE']
+        self.create_queue = 'etsin-create'
+        self.update_queue = 'etsin-update'
+        self.delete_queue = 'etsin-delete'
 
-        exchange = rabbit_settings['EXCHANGE']
-        queue_1 = 'etsin-create'
-        queue_2 = 'etsin-update'
-        queue_3 = 'etsin-delete'
-
-        self.channel.queue_declare(queue_1, durable=True)
-        self.channel.queue_declare(queue_2, durable=True)
-        self.channel.queue_declare(queue_3, durable=True)
-
-        self.channel.queue_bind(exchange=exchange, queue=queue_1, routing_key='create')
-        self.channel.queue_bind(exchange=exchange, queue=queue_2, routing_key='update')
-        self.channel.queue_bind(exchange=exchange, queue=queue_3, routing_key='delete')
-
-        # Set up ElasticSearch client
-        es_client = ElasticSearchService(es_settings)
-        if not es_client.index_exists():
-            if not es_client.create_index_and_mapping():
-                # If there's no ES index, don't create consumer
-                raise Exception
+        self._create_and_bind_queues()
 
         def callback_reindex(ch, method, properties, body):
+            self.indexing_operation_complete = False
+            self.log.debug("Received create or update message from Metax RabbitMQ")
+
+            if not self._ensure_index_existence():
+                ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                self.indexing_operation_complete = True
+                return
+
+            body_as_json = self._get_message_body_as_json(body)
+            if not body_as_json:
+                ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                self.indexing_operation_complete = True
+                return
+
             converter = CRConverter()
-            es_data_model = converter.convert_metax_catalog_record_json_to_es_data_model(
-                json.loads(body))
-            reindex_success = False
+            es_data_model = converter.convert_metax_catalog_record_json_to_es_data_model(body_as_json)
+
+            if not es_data_model:
+                ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                self.indexing_operation_complete = True
+                return
+
+            es_reindex_success = False
             try:
-                reindex_success = es_client.reindex_dataset(es_data_model)
+                es_reindex_success = self.es_client.reindex_dataset(es_data_model)
             except RequestError:
-                reindex_success = False
+                es_reindex_success = False
             finally:
-                if reindex_success:
+                if es_reindex_success:
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                 else:
-                    self.log.info('Failed to reindex %s', json.loads(
+                    self.log.error('Failed to reindex %s', json.loads(
                         body).get('urn_identifier', 'unknown identifier'))
                     ch.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
 
+                self.indexing_operation_complete = True
+
         def callback_delete(ch, method, properties, body):
+            self.indexing_operation_complete = False
+            self.log.debug("Received delete message from Metax RabbitMQ")
+
+            if not self._ensure_index_existence():
+                ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                self.indexing_operation_complete = True
+                return
+
+            body_as_json = self._get_message_body_as_json(body)
+            if not body_as_json:
+                ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                self.indexing_operation_complete = True
+                return
+
             delete_success = False
             try:
-                delete_success = es_client.delete_dataset(json.loads(body).get('urn_identifier'))
+                delete_success = self.es_client.delete_dataset(body_as_json.get('urn_identifier'))
             except RequestError:
                 delete_success = False
             finally:
                 if delete_success:
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                 else:
-                    self.log.info('Failed to delete %s', json.loads(
+                    self.log.error('Failed to delete %s', json.loads(
                         body).get('urn_identifier', 'unknown identifier'))
                     # TODO: If delete fails because there's no such id in index,
                     # no need to requeue
                     ch.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
 
-        # Set up consumer
-        self.channel.basic_consume(callback_reindex, queue=queue_1)
-        self.channel.basic_consume(callback_reindex, queue=queue_2)
-        self.channel.basic_consume(callback_delete, queue=queue_3)
+                self.indexing_operation_complete = True
+
+        # Set up consumers
+        self.create_consumer_tag = self.channel.basic_consume(callback_reindex, queue=self.create_queue)
+        self.update_consumer_tag = self.channel.basic_consume(callback_reindex, queue=self.update_queue)
+        self.delete_consumer_tag = self.channel.basic_consume(callback_delete, queue=self.delete_queue)
+
+        self.init_ok = True
 
     def run(self):
-        self.log.info('[*] RabbitMQ client started')
+        self.log.info('RabbitMQ client starting to consume messages..')
         print('[*] RabbitMQ is running. To exit press CTRL+C. See logs for indexing details.')
         self.channel.start_consuming()
+
+    def before_stop(self):
+        self._cancel_consumers()
+
+    def _get_message_body_as_json(self, body):
+        try:
+            return json.loads(body)
+        except ValueError:
+            self.log.error("RabbitMQ message cannot be interpreted as json")
+
+        return None
+
+    def _cancel_consumers(self):
+        self.channel.basic_cancel(consumer_tag=self.create_consumer_tag)
+        self.channel.basic_cancel(consumer_tag=self.update_consumer_tag)
+        self.channel.basic_cancel(consumer_tag=self.delete_consumer_tag)
+
+    def _create_and_bind_queues(self):
+        self.channel.queue_declare(self.create_queue, durable=True)
+        self.channel.queue_declare(self.update_queue, durable=True)
+        self.channel.queue_declare(self.delete_queue, durable=True)
+
+        self.channel.queue_bind(exchange=self.exchange, queue=self.create_queue, routing_key='create')
+        self.channel.queue_bind(exchange=self.exchange, queue=self.update_queue, routing_key='update')
+        self.channel.queue_bind(exchange=self.exchange, queue=self.delete_queue, routing_key='delete')
+
+    def _ensure_index_existence(self):
+        if not self.es_client.index_exists():
+            if not self.es_client.create_index_and_mapping():
+                # If there's no ES index, don't create consumer
+                self.log.error("Unable to create Elasticsearch index and type mapping")
+                return False
+
+        return True

--- a/etsin_finder_search/utils.py
+++ b/etsin_finder_search/utils.py
@@ -1,6 +1,7 @@
 import json
 import yaml
 import os
+import subprocess
 
 
 def get_config_from_file():
@@ -47,3 +48,34 @@ def executing_travis():
     Returns True whenever code is being executed by travis
     """
     return True if os.getenv('TRAVIS', False) else False
+
+
+def stop_rabbitmq_consumer():
+    """
+    Stop rabbitmq-consumer systemd service. Waits for exit or raises an error
+    :return:
+    """
+    try:
+        subprocess.check_call("sudo service rabbitmq-consumer stop".split())
+        return True
+    except subprocess.CalledProcessError as e:
+        return False
+
+
+def start_rabbitmq_consumer():
+    """
+    Start rabbitmq-consumer systemd service.
+    :return:
+    """
+    try:
+        subprocess.check_call("sudo service rabbitmq-consumer start".split())
+        return True
+    except subprocess.CalledProcessError as e:
+        return False
+
+
+def rabbitmq_consumer_is_running():
+    output = str(subprocess.check_output(['ps', 'aux']))
+    if 'run_rabbitmq_consumer.py' in output:
+        return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch==5.4.0
+elasticsearch==5.5.1
 flake8==3.5.0
 pika==0.11.0
 pytest==3.2.3

--- a/run_rabbitmq_consumer.py
+++ b/run_rabbitmq_consumer.py
@@ -1,6 +1,47 @@
 #!/usr/bin/python
 
-from etsin_finder_search.rabbitmq.rabbitmq_client import MetaxConsumer
+import signal
+import sys
+import time
 
+from etsin_finder_search.rabbitmq.rabbitmq_client import MetaxConsumer
+from etsin_finder_search.reindexing_log import get_logger
+
+
+log = get_logger(__name__)
+log.info("Initializing RabbitMQ consumer..")
 consumer = MetaxConsumer()
-consumer.run()
+
+
+def signal_term_handler(signal, frame):
+    """
+    Handler for the sigterm event occurring when the running of this code is being terminated by systemd.
+    First cancel consumers in order not to receive any more messages. After that for 10 seconds
+    wait for the current reindexing operation to finish. After that exit the program anyway.
+
+    :param signal:
+    :param frame:
+    :return:
+    """
+
+    consumer.before_stop()
+    reindexing_ongoing = not consumer.indexing_operation_complete
+    i = 0
+    while reindexing_ongoing and i < 10:
+        log.info("Waiting for reindexing operation to finish before exiting RabbitMQ consumer..")
+        time.sleep(1)
+        reindexing_ongoing = not consumer.indexing_operation_complete
+        i += 1
+
+    log.info("Exiting RabbitMQ consumer")
+    sys.exit(0)
+
+
+# If consumer initialized ok (i.e. finished the __init__ without returning), start consuming
+if consumer.init_ok:
+    log.info("RabbitMQ consumer initialized")
+    signal.signal(signal.SIGTERM, signal_term_handler)
+    consumer.run()
+else:
+    log.error("Consumer not initialized, exiting service")
+    sys.exit(1)


### PR DESCRIPTION
…earch daily reindexing operation. On rabbitmq consumer service stop remove consumers from listening the queues and wait for current rabbitmq operation to finish (up until 10 seconds). On initializing rabbitmq consumer, in case of various problems, exit the service. In some problem cases try again for some time before giving up. The rabbitmq service itself, if it exits with other than 0, in etsin-ops service definition it is declared systemd should restart the service. On receiving rabbitmq messages, make sure rabbitmq messages are readable as json and that the target elasticsearch index exists, otherwise send nack and no requeue.