### PR TITLE
CSCETSIN-237: Update organization and project name indexing

### DIFF
--- a/etsin_finder_search/catalog_record_converter.py
+++ b/etsin_finder_search/catalog_record_converter.py
@@ -248,7 +248,7 @@ class CRConverter:
 
     def _convert_metax_langstring_name_to_es_model(self, m_input, es_output, relation_name_base):
         """
-        Converts an object with langstring name to two lists, one for Finnish and one for English name.        
+        Converts an object with langstring name to two lists, one for Finnish and one for English name.
 
         :param m_input:
         :param es_output:

--- a/etsin_finder_search/catalog_record_converter.py
+++ b/etsin_finder_search/catalog_record_converter.py
@@ -24,8 +24,11 @@ class CRConverter:
 
             m_rd = metax_cr_json['research_dataset']
 
-            if 'organization_name' not in es_dataset:
-                es_dataset['organization_name'] = []
+            if 'organization_name_fi' not in es_dataset:
+                es_dataset['organization_name_fi'] = []
+
+            if 'organization_name_en' not in es_dataset:
+                es_dataset['organization_name_en'] = []
 
             if metax_cr_json.get('date_modified', False):
                 es_dataset['date_modified'] = metax_cr_json.get('date_modified')
@@ -109,16 +112,19 @@ class CRConverter:
 
             for m_is_output_of_item in m_rd.get('is_output_of', []):
                 if m_is_output_of_item.get('has_funding_agency', []):
-                    self._convert_metax_organization_name_to_es_model(m_is_output_of_item.get('has_funding_agency'), es_dataset, 'organization_name')
+                    self._convert_metax_langstring_name_to_es_model(m_is_output_of_item.get('has_funding_agency'), es_dataset, 'organization_name')
 
                 if m_is_output_of_item.get('source_organization', []):
-                    self._convert_metax_organization_name_to_es_model(m_is_output_of_item.get('source_organization'), es_dataset, 'organization_name')
+                    self._convert_metax_langstring_name_to_es_model(m_is_output_of_item.get('source_organization'), es_dataset, 'organization_name')
 
             if m_rd.get('is_output_of', []):
-                if 'project_name' not in es_dataset:
-                    es_dataset['project_name'] = []
+                if 'project_name_fi' not in es_dataset:
+                    es_dataset['project_name_fi'] = []
 
-                self._convert_metax_project_name_to_es_model(m_rd.get('is_output_of'), es_dataset, 'project_name')
+                if 'project_name_en' not in es_dataset:
+                    es_dataset['project_name_en'] = []
+
+                self._convert_metax_langstring_name_to_es_model(m_rd.get('is_output_of'), es_dataset, 'project_name')
 
             if 'file_type' not in es_dataset and (m_rd.get('files', False) or m_rd.get('remote_resources', False)):
                 es_dataset['file_type'] = []
@@ -133,28 +139,28 @@ class CRConverter:
             if m_rd.get('contributor', False):
                 es_dataset['contributor'] = []
                 self._convert_metax_org_or_person_to_es_model(m_rd.get('contributor'), es_dataset, 'contributor')
-                self._convert_metax_organization_name_to_es_model(m_rd.get('contributor'), es_dataset, 'organization_name')
+                self._convert_metax_langstring_name_to_es_model(m_rd.get('contributor'), es_dataset, 'organization_name')
 
             if m_rd.get('publisher', False):
                 es_dataset['publisher'] = []
                 self._convert_metax_org_or_person_to_es_model(m_rd.get('publisher'), es_dataset, 'publisher')
-                self._convert_metax_organization_name_to_es_model(m_rd.get('publisher'), es_dataset, 'organization_name')
+                self._convert_metax_langstring_name_to_es_model(m_rd.get('publisher'), es_dataset, 'organization_name')
 
             if m_rd.get('curator', False):
                 es_dataset['curator'] = []
                 self._convert_metax_org_or_person_to_es_model(m_rd.get('curator'), es_dataset, 'curator')
-                self._convert_metax_organization_name_to_es_model(m_rd.get('curator'), es_dataset, 'organization_name')
+                self._convert_metax_langstring_name_to_es_model(m_rd.get('curator'), es_dataset, 'organization_name')
 
             if m_rd.get('creator', False):
                 es_dataset['creator'] = []
                 self._convert_metax_org_or_person_to_es_model(m_rd.get('creator'), es_dataset, 'creator')
                 self._convert_metax_creator_name_to_es_model(m_rd.get('creator'), es_dataset, 'creator_name')
-                self._convert_metax_organization_name_to_es_model(m_rd.get('creator'), es_dataset, 'organization_name')
+                self._convert_metax_langstring_name_to_es_model(m_rd.get('creator'), es_dataset, 'organization_name')
 
             if m_rd.get('rights_holder', False):
                 es_dataset['rights_holder'] = []
                 self._convert_metax_org_or_person_to_es_model(m_rd.get('rights_holder'), es_dataset, 'rights_holder')
-                self._convert_metax_organization_name_to_es_model(m_rd.get('rights_holder'), es_dataset, 'organization_name')
+                self._convert_metax_langstring_name_to_es_model(m_rd.get('rights_holder'), es_dataset, 'organization_name')
 
         return es_dataset
 
@@ -240,8 +246,9 @@ class CRConverter:
 
         es_output[relation_name] = output
 
-    def _convert_metax_project_name_to_es_model(self, m_input, es_output, relation_name):
+    def _convert_metax_langstring_name_to_es_model(self, m_input, es_output, relation_name_base):
         """
+        Converts an object with langstring name to two lists, one for Finnish and one for English name.        
 
         :param m_input:
         :param es_output:
@@ -249,49 +256,33 @@ class CRConverter:
         :return:
         """
 
-        output = []
+        output_fi = []
+        output_en = []
         if isinstance(m_input, list):
             for m_obj in m_input:
-                name = self._get_converted_project_name_es_model(m_obj)
-                if name is not None:
-                    output.extend(name)
-        else:
-            if m_input:
-                name = self._get_converted_project_name_es_model(m_input)
-                if name is not None:
-                    output.extend(name)
+                name_fi = self._get_converted_langstring_name_es_model(m_obj, 'fi')
+                name_en = self._get_converted_langstring_name_es_model(m_obj, 'en')
+                if name_fi is not None and name_en is not None:
+                    output_fi.append(name_fi)
+                    output_en.append(name_en)
 
-        es_output[relation_name] = output
-
-    def _convert_metax_organization_name_to_es_model(self, m_input, es_output, relation_name):
-        """
-
-        :param m_input:
-        :param es_output:
-        :param relation_name:
-        :return:
-        """
-
-        output = []
-        if isinstance(m_input, list):
-            for m_obj in m_input:
-                name = self._get_converted_organization_name_es_model(m_obj)
-                if name is not None:
-                    output.extend(name)
                 if 'is_part_of' in m_obj:
-                    self._convert_metax_organization_name_to_es_model(m_obj['is_part_of'], es_output, relation_name)
+                    self._convert_metax_langstring_name_to_es_model(m_obj['is_part_of'], es_output, relation_name_base)
                 if 'member_of' in m_obj:
-                    self._convert_metax_organization_name_to_es_model(m_obj['member_of'], es_output, relation_name)
+                    self._convert_metax_langstring_name_to_es_model(m_obj['member_of'], es_output, relation_name_base)
         else:
             if m_input:
-                output = self._get_converted_organization_name_es_model(m_input)
-                if 'is_part_of' in m_input:
-                    self._convert_metax_organization_name_to_es_model(m_input['is_part_of'], es_output, relation_name)
-                if 'member_of' in m_input:
-                    self._convert_metax_organization_name_to_es_model(m_input['member_of'], es_output, relation_name)
+                output_fi.append(self._get_converted_langstring_name_es_model(m_input, 'fi'))
+                output_en.append(self._get_converted_langstring_name_es_model(m_input, 'en'))
 
-        if output is not None:
-            es_output[relation_name].extend(output)
+                if 'is_part_of' in m_input:
+                    self._convert_metax_langstring_name_to_es_model(m_input['is_part_of'], es_output, relation_name_base)
+                if 'member_of' in m_input:
+                    self._convert_metax_langstring_name_to_es_model(m_input['member_of'], es_output, relation_name_base)
+
+        if output_fi is not None and output_en is not None:
+            es_output[relation_name_base + '_fi'].extend(output_fi)
+            es_output[relation_name_base + '_en'].extend(output_en)
 
     def _get_converted_single_org_or_person_es_model(self, m_obj):
         if m_obj.get('@type', '') not in ['Person', 'Organization']:
@@ -318,22 +309,25 @@ class CRConverter:
 
         return out_obj
 
-    def _get_converted_project_name_es_model(self, m_obj):
-        name = m_obj.get('name', '')
+    def _get_converted_langstring_name_es_model(self, m_obj, lang):
         if not isinstance(m_obj.get('name'), dict):
-            name = {'und': m_obj.get('name', '')}
-
-        out_obj = list(name.values())
-
-        return out_obj
-
-    def _get_converted_organization_name_es_model(self, m_obj):
-        if m_obj.get('@type', '') != 'Organization':
             return None
 
-        org = self._get_es_person_or_org_common_data_from_metax_obj(m_obj)
-        out_obj = list(org['name'].values())
-        out_obj = [x for x in out_obj if x] # remove empty strings
+        if lang is 'fi':
+            preferred_order = ['fi', 'und', 'en']
+        elif lang is 'en':
+            preferred_order = ['en', 'und', 'fi']
+        else:
+            return None
+
+        for language in preferred_order:
+            try:
+                return m_obj['name'][language]
+            except KeyError:
+                continue
+
+        # If name is not available in preferred languages, choose any name
+        out_obj = list(m_obj['name'].values())[0]
 
         return out_obj
 

--- a/etsin_finder_search/elastic/resources/dataset_type_mapping.json
+++ b/etsin_finder_search/elastic/resources/dataset_type_mapping.json
@@ -68,7 +68,31 @@
         }
       }      
     },
-    "organization_name": {
+    "organization_name_fi": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword"
+        }
+      }      
+    },
+    "organization_name_en": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword"
+        }
+      }      
+    },
+    "project_name_fi": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword"
+        }
+      }      
+    },
+    "project_name_en": {
       "type": "text",
       "fields": {
         "keyword": {
@@ -107,14 +131,6 @@
       "type": "text",
       "copy_to": ["theme.label.en", "theme.label.fi"]
     },
-    "project_name": {
-      "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword"
-        }
-      }      
-    },    
     "preservation_state": {
       "type": "integer"
     }

--- a/tests/test_objects/es_document.json
+++ b/tests/test_objects/es_document.json
@@ -155,22 +155,28 @@
         "keyword2",
         "keyword3"
     ],
-    "organization_name": [
-        "Funding Organization",
-        "Organisaatio",
+    "organization_name_en": ["Funding Organization",
         "Helsingin yliopisto",
         "Helsingin yliopisto",
         "Mysterious Organization 2",
-        "Organisaatio",
         "Aalto yliopisto",
         "School services, ARTS",
         "Aalto yliopisto",
         "Mysterious Organization",
+        "Aalto yliopisto",
+        "Aalto yliopisto",
+        "Helsingin yliopisto"],
+    "organization_name_fi": ["Organisaatio",
+        "Helsingin yliopisto",
+        "Helsingin yliopisto",
+        "Organisaatio",
+        "Aalto yliopisto",
+        "School services, ARTS",
+        "Aalto yliopisto",
         "Organisaatio",
         "Aalto yliopisto",
         "Aalto yliopisto",
-        "Helsingin yliopisto"
-    ],
+        "Helsingin yliopisto"],
     "other_identifier": [
         {
             "notation": "doi:10.12345",
@@ -200,9 +206,8 @@
         }
     ],
     "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9613",
-    "project_name": [
-        "Name of project"
-    ],
+    "project_name_en": ["Name of project"],
+    "project_name_fi": ["Name of project"],
     "publisher": {
         "agent_type": "Organization",
         "belongs_to_org": {


### PR DESCRIPTION
**This feature changes both etsin-finder and etsin-finder-search**

Makes "number of projects" on front page more accurate and reduces number of duplicate items in "organization" and "project" facets on search results page. Doesn't make things perfect, but the improvement should be visible.

Under the hood, organization and project names are split into language-specific fields that always have the same amount of items. Items in *_fi prefer Finnish names whenever they're available, English works likewise. If preferred language is not available, another name is picked.

Search result page facets use these fields to ensure facet values are displayed in user interface language as much as possible.

Number of distinct English project names is displayed on front page.