### PR TITLE
CSCETSIN-302: Add 'data_catalog_identifier' to elastic search dataset

### DIFF
--- a/etsin_finder_search/catalog_record_converter.py
+++ b/etsin_finder_search/catalog_record_converter.py
@@ -12,7 +12,8 @@ from etsin_finder_search.utils import \
     catalog_record_has_identifier, \
     get_catalog_record_identifier, \
     get_catalog_record_dataset_version_set, \
-    get_catalog_record_data_catalog_title
+    get_catalog_record_data_catalog_title, \
+    get_catalog_record_data_catalog_identifier
 
 log = get_logger(__name__)
 
@@ -29,6 +30,7 @@ class CRConverter:
             es_dataset['preferred_identifier'] = get_catalog_record_preferred_identifier(metax_cr_json)
             es_dataset['dataset_version_set'] = get_catalog_record_dataset_version_set(metax_cr_json)
             es_dataset['data_catalog'] = get_catalog_record_data_catalog_title(metax_cr_json)
+            es_dataset['data_catalog_identifier'] = get_catalog_record_data_catalog_identifier(metax_cr_json)
 
             m_rd = metax_cr_json['research_dataset']
 

--- a/tests/test_objects/es_document.json
+++ b/tests/test_objects/es_document.json
@@ -128,6 +128,7 @@
     "dataset_version_set": [
         "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9613"
     ],
+    "data_catalog_identifier": "urn:nbn:fi:att:data-catalog-att",
     "date_modified": "2019-01-30T09:40:38+02:00",
     "description": {
         "en": "A descriptive description describing the contents of this dataset. Must be descriptive."

--- a/tests/test_objects/es_document.json
+++ b/tests/test_objects/es_document.json
@@ -128,7 +128,7 @@
     "dataset_version_set": [
         "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9613"
     ],
-    "data_catalog_identifier": "urn:nbn:fi:att:data-catalog-att",
+    "data_catalog_identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d1",
     "date_modified": "2019-01-30T09:40:38+02:00",
     "description": {
         "en": "A descriptive description describing the contents of this dataset. Must be descriptive."


### PR DESCRIPTION
- This field is important when checking PAS and non-PAS datasets in Etsin's frontend
- Added the field using an existing function in utils.py