### PR TITLE
CSCETSIN-302: Exclude datasets with preservation_dataset_origin_version

### DIFF
--- a/etsin_finder_search/rabbitmq/rabbitmq_client.py
+++ b/etsin_finder_search/rabbitmq/rabbitmq_client.py
@@ -149,6 +149,16 @@ class MetaxConsumer():
                     "from index...".format(incoming_cr_id, prev_version_cr_id))
                 self.es_client.delete_dataset_from_index(prev_version_cr_id)
 
+            # If catalog_has_preservation_dataset_origin_version is found, it means the dataset is stored in PAS and has an original version.
+            # This original version will be displayed in the dataset list instead, so this PAS dataset version should be excluded.
+            if catalog_has_preservation_dataset_origin_version(body_as_json):
+                self.log.info("Identifier {0} is a PAS dataset, and has a dataset in original version. "
+                                "Trying to delete from index if it exists..".format(incoming_cr_id))
+                self._delete_from_index(ch, method, body_as_json)
+                ch.basic_ack(delivery_tag=method.delivery_tag)
+                self.event_processing_completed = True
+                return
+
             self._convert_to_es_doc_and_reindex(ch, method, body_as_json)
 
         def callback_update(ch, method, properties, body):
@@ -162,12 +172,21 @@ class MetaxConsumer():
             if catalog_record_has_identifier(body_as_json):
                 incoming_cr_id = get_catalog_record_identifier(body_as_json)
 
-                # 1. If catalog record has been deprecated, delete it from index
-                # 2. If catalog_has_preservation_dataset_origin_version is found, it means the dataset is stored in PAS and has an original version.
-                # This original version will be displayed in the dataset list instead, so this PAS dataset version should be excluded.
-                if ((catalog_record_is_deprecated(body_as_json)) or (catalog_has_preservation_dataset_origin_version(body_as_json))):
+                # If catalog record has been deprecated, delete it from index
+                if catalog_record_is_deprecated(body_as_json):
                     self.log.info("Identifier {0} is deprecated. "
                                   "Trying to delete from index if it exists..".format(incoming_cr_id))
+                    self._delete_from_index(ch, method, body_as_json)
+                    ch.basic_ack(delivery_tag=method.delivery_tag)
+                    self.event_processing_completed = True
+                    return
+
+                # If catalog_has_preservation_dataset_origin_version is found, it means the dataset is stored in PAS and has an original version.
+                # This original version will be displayed in the dataset list instead, so this PAS dataset version should be excluded.
+                # Dataset must be excluded here in callback_update as well, to prevent it appearning in the list again, after an update of the dataset
+                if catalog_has_preservation_dataset_origin_version(body_as_json):
+                    self.log.info("Identifier {0} is a PAS dataset, and has a dataset in original version. "
+                                    "Trying to delete from index if it exists..".format(incoming_cr_id))
                     self._delete_from_index(ch, method, body_as_json)
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                     self.event_processing_completed = True

--- a/etsin_finder_search/rabbitmq/rabbitmq_client.py
+++ b/etsin_finder_search/rabbitmq/rabbitmq_client.py
@@ -153,7 +153,7 @@ class MetaxConsumer():
             # This original version will be displayed in the dataset list instead, so this PAS dataset version should be excluded.
             if catalog_has_preservation_dataset_origin_version(body_as_json):
                 self.log.info("Identifier {0} is a PAS dataset, and has a dataset in original version. "
-                                "Trying to delete from index if it exists..".format(incoming_cr_id))
+                              "Trying to delete from index if it exists..".format(incoming_cr_id))
                 self._delete_from_index(ch, method, body_as_json)
                 ch.basic_ack(delivery_tag=method.delivery_tag)
                 self.event_processing_completed = True
@@ -186,7 +186,7 @@ class MetaxConsumer():
                 # Dataset must be excluded here in callback_update as well, to prevent it appearning in the list again, after an update of the dataset
                 if catalog_has_preservation_dataset_origin_version(body_as_json):
                     self.log.info("Identifier {0} is a PAS dataset, and has a dataset in original version. "
-                                    "Trying to delete from index if it exists..".format(incoming_cr_id))
+                                  "Trying to delete from index if it exists..".format(incoming_cr_id))
                     self._delete_from_index(ch, method, body_as_json)
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                     self.event_processing_completed = True

--- a/etsin_finder_search/rabbitmq/rabbitmq_client.py
+++ b/etsin_finder_search/rabbitmq/rabbitmq_client.py
@@ -38,6 +38,7 @@ from etsin_finder_search.utils import \
     catalog_record_has_next_dataset_version, \
     catalog_record_has_previous_dataset_version, \
     catalog_record_is_deprecated, \
+    catalog_has_preservation_dataset_origin_version, \
     catalog_record_has_preferred_identifier, \
     catalog_record_has_identifier, \
     catalog_record_should_be_indexed, \
@@ -161,8 +162,10 @@ class MetaxConsumer():
             if catalog_record_has_identifier(body_as_json):
                 incoming_cr_id = get_catalog_record_identifier(body_as_json)
 
-                # If catalog record has been deprecated, delete it from index
-                if catalog_record_is_deprecated(body_as_json):
+                # 1. If catalog record has been deprecated, delete it from index
+                # 2. If catalog_has_preservation_dataset_origin_version is found, it means the dataset is stored in PAS and has an original version.
+                # This original version will be displayed in the dataset list instead, so this PAS dataset version should be excluded.
+                if ((catalog_record_is_deprecated(body_as_json)) or (catalog_has_preservation_dataset_origin_version(body_as_json))):
                     self.log.info("Identifier {0} is deprecated. "
                                   "Trying to delete from index if it exists..".format(incoming_cr_id))
                     self._delete_from_index(ch, method, body_as_json)

--- a/etsin_finder_search/reindexer.py
+++ b/etsin_finder_search/reindexer.py
@@ -17,6 +17,7 @@ from etsin_finder_search.utils import \
     stop_rabbitmq_consumer, \
     rabbitmq_consumer_is_running, \
     catalog_record_is_deprecated, \
+    catalog_has_preservation_dataset_origin_version, \
     catalog_record_should_be_indexed
 
 
@@ -122,7 +123,10 @@ def convert_identifiers_to_es_data_models(metax_api, identifiers_to_convert, ide
                 continue
 
         if metax_cr_json:
-            if catalog_record_is_deprecated(metax_cr_json):
+            # 1. If catalog record has been deprecated, delete its identifier from index
+            # 2. If catalog_has_preservation_dataset_origin_version is found, it means the dataset is stored in PAS and has an original version.
+            #    This original version will be displayed in the dataset list instead, so this PAS dataset version identifier should be excluded.
+            if ((catalog_record_is_deprecated(metax_cr_json)) or (catalog_has_preservation_dataset_origin_version(metax_cr_json))):
                 identifiers_to_delete.append(identifier)
                 continue
 

--- a/etsin_finder_search/utils.py
+++ b/etsin_finder_search/utils.py
@@ -145,6 +145,8 @@ def catalog_record_has_next_dataset_version(cr_json):
 def catalog_record_is_deprecated(cr_json):
     return cr_json.get('deprecated', False)
 
+def catalog_has_preservation_dataset_origin_version(cr_json):
+    return cr_json.get('preservation_dataset_origin_version', False)
 
 def catalog_record_should_be_indexed(cr_json):
     dc_identifier = get_catalog_record_data_catalog_identifier(cr_json)


### PR DESCRIPTION
- Datasets with the field 'preservation_dataset_origin_version' should be excluded from elastic search. 
- These datasets are PAS datasets that exist in two versions, one in PAS and one normal version. The PAS version is now excluded from elasticSearch, displaying only the original version of the dataset. Navigating to the original version, through Etsin, will display a link to the PAS version. 
- Added functionality that checks if 'preservation_dataset_origin_version' exists. These checks run both the first time a dataset enters elastic search (callback_create), and on possible updates (callback_update)