### PR TITLE
CSCFAIRMETA-338-fix-travis: Travis deployment fix

### DIFF
--- a/.travis-deploy.sh
+++ b/.travis-deploy.sh
@@ -6,7 +6,7 @@ if [[ "$TRAVIS_BRANCH" == "master" || "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     exit 0
 fi
 
-pip install ansible
+pip install ansible==2.8.6
 git clone https://github.com/CSCfi/etsin-ops
 cd etsin-ops/ansible/
 


### PR DESCRIPTION
- Travis is failing, likely because of the missing ansible version specification, causing ansible to use 2.9 or some newer incompatible version
- Added ansible version specification (2.8.6), similar to how the issue was fixed in the etsin-finder repository