### PR TITLE
CSCFAIRMETA-368: Fix indexing logic for PAS datasets.

### DIFF
--- a/etsin_finder_search/rabbitmq/rabbitmq_client.py
+++ b/etsin_finder_search/rabbitmq/rabbitmq_client.py
@@ -161,7 +161,7 @@ class MetaxConsumer():
                 ch.basic_ack(delivery_tag=method.delivery_tag)
                 self.event_processing_completed = True
                 return
-            
+
             # If catalog is  PAS and the preservation state is NOT 120, then it should not be indexed.
             # Also remove it from the index if it already is there.
             if catalog_record_is_pas_catalog(body_as_json) and get_catalog_preservation_state(body_as_json) != 120:

--- a/etsin_finder_search/rabbitmq/rabbitmq_client.py
+++ b/etsin_finder_search/rabbitmq/rabbitmq_client.py
@@ -42,7 +42,9 @@ from etsin_finder_search.utils import \
     catalog_record_has_preferred_identifier, \
     catalog_record_has_identifier, \
     catalog_record_should_be_indexed, \
-    get_catalog_record_identifier
+    get_catalog_record_identifier, \
+    catalog_record_is_pas_catalog, \
+    get_catalog_preservation_state
 
 
 class MetaxConsumer():
@@ -149,6 +151,27 @@ class MetaxConsumer():
                     "from index...".format(incoming_cr_id, prev_version_cr_id))
                 self.es_client.delete_dataset_from_index(prev_version_cr_id)
 
+            # If catalog_has_preservation_dataset_origin_version is found, it means the dataset is stored in PAS and has an original version.
+            # This original version will be displayed in the dataset list instead, so this PAS dataset version should be excluded.
+            if catalog_has_preservation_dataset_origin_version(body_as_json):
+                incoming_cr_id = get_catalog_record_identifier(body_as_json)
+                self.log.info("Identifier {0} is a PAS dataset, and has a dataset in original version. "
+                            "Trying to delete from index if it exists..".format(incoming_cr_id))
+                self._delete_from_index(ch, method, body_as_json)
+                ch.basic_ack(delivery_tag=method.delivery_tag)
+                self.event_processing_completed = True
+                return
+            
+            # If catalog is  PAS and the preservation state is NOT 120, then it should not be indexed.
+            # Also remove it from the index if it already is there.
+            if catalog_record_is_pas_catalog(body_as_json) and get_catalog_preservation_state(body_as_json) != 120:
+                incoming_cr_id = get_catalog_record_identifier(body_as_json)
+                self.log.info("Identifier {0} is a PAS dataset with preservation_state other than 120, Trying to delete from index if it exists..".format(incoming_cr_id))
+                self._delete_from_index(ch, method, body_as_json)
+                ch.basic_ack(delivery_tag=method.delivery_tag)
+                self.event_processing_completed = True
+                return
+
             self._convert_to_es_doc_and_reindex(ch, method, body_as_json)
 
         def callback_update(ch, method, properties, body):
@@ -175,6 +198,25 @@ class MetaxConsumer():
                 if catalog_record_has_next_dataset_version(body_as_json):
                     self.log.info("Identifier {0} has a next dataset version. Skipping reindexing..."
                                   .format(incoming_cr_id))
+                    ch.basic_ack(delivery_tag=method.delivery_tag)
+                    self.event_processing_completed = True
+                    return
+
+                # If catalog_has_preservation_dataset_origin_version is found, it means the dataset is stored in PAS and has an original version.
+                # This original version will be displayed in the dataset list instead, so this PAS dataset version should be excluded.
+                if catalog_has_preservation_dataset_origin_version(body_as_json):
+                    self.log.info("Identifier {0} is a PAS dataset, and has a dataset in original version. "
+                                "Trying to delete from index if it exists..".format(incoming_cr_id))
+                    self._delete_from_index(ch, method, body_as_json)
+                    ch.basic_ack(delivery_tag=method.delivery_tag)
+                    self.event_processing_completed = True
+                    return
+
+                # If catalog is  PAS and the preservation state is NOT 120, then it should not be indexed.
+                # Also remove it from the index if it already is there.
+                if catalog_record_is_pas_catalog(body_as_json) and get_catalog_preservation_state(body_as_json) != 120:
+                    self.log.info("Identifier {0} is a PAS dataset with preservation_state other than 120, Trying to delete from index if it exists..".format(incoming_cr_id))
+                    self._delete_from_index(ch, method, body_as_json)
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                     self.event_processing_completed = True
                     return

--- a/etsin_finder_search/reindexer.py
+++ b/etsin_finder_search/reindexer.py
@@ -18,7 +18,9 @@ from etsin_finder_search.utils import \
     rabbitmq_consumer_is_running, \
     catalog_record_is_deprecated, \
     catalog_has_preservation_dataset_origin_version, \
-    catalog_record_should_be_indexed
+    catalog_record_should_be_indexed, \
+    catalog_record_is_pas_catalog, \
+    get_catalog_preservation_state
 
 
 log = get_logger(__name__)
@@ -127,6 +129,10 @@ def convert_identifiers_to_es_data_models(metax_api, identifiers_to_convert, ide
             # 2. If catalog_has_preservation_dataset_origin_version is found, it means the dataset is stored in PAS and has an original version.
             #    This original version will be displayed in the dataset list instead, so this PAS dataset version identifier should be excluded.
             if ((catalog_record_is_deprecated(metax_cr_json)) or (catalog_has_preservation_dataset_origin_version(metax_cr_json))):
+                identifiers_to_delete.append(identifier)
+                continue
+
+            if (catalog_record_is_pas_catalog(metax_cr_json) and get_catalog_preservation_state(metax_cr_json) != 120):
                 identifiers_to_delete.append(identifier)
                 continue
 

--- a/etsin_finder_search/utils.py
+++ b/etsin_finder_search/utils.py
@@ -148,6 +148,12 @@ def catalog_record_is_deprecated(cr_json):
 def catalog_has_preservation_dataset_origin_version(cr_json):
     return cr_json.get('preservation_dataset_origin_version', False)
 
+def get_catalog_preservation_state(cr_json):
+    return cr_json.get('preservation_state', 0)
+
+def catalog_record_is_pas_catalog(cr_json):
+    return get_catalog_record_data_catalog_identifier(cr_json) == 'urn:nbn:fi:att:data-catalog-pas'
+
 def catalog_record_should_be_indexed(cr_json):
     dc_identifier = get_catalog_record_data_catalog_identifier(cr_json)
     if dc_identifier is None:


### PR DESCRIPTION
- PAS datasets should only be searchable in etsin if they are not created from
  another dataset and if the preservation_state is 120.
- In both the reindexer and in the rabbitmq consumer check theese conditions
  with the utils functions: catalog_record_is_pas_catalog, get_catalog_preservation_state
  catalog_has_preservation_dataset_origin_version
- Effects PAS dataset searchability in etsin.