### PR TITLE
CSCFAIRADM-424: Update Travis links

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,6 @@
-etsin-finder service is made by:
+etsin-finder-search has been developed by:
 
-Juha-Matti Lehtinen
-Meeri Panula
+junsk1
+Meepu
+kasperkeinanen
+MattiasLevlin

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 CSC - IT Center for Science Ltd.
+Copyright (c) 2018-2020 CSC - IT Center for Science Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This repository contains code for Etsin Finder Search
 
 License
 -------
-Copyright (c) 2018 Ministry of Education and Culture, Finland
+Copyright (c) 2018-2020 Ministry of Education and Culture, Finland
 
 Licensed under [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ This repository contains code for Etsin Finder Search
 # Build status
 
 ## Test branch
-[![Build Status](https://travis-ci.org/CSCfi/etsin-finder-search.svg?branch=test)](https://travis-ci.org/CSCfi/etsin-finder-search)
+[![Build Status](https://travis-ci.com/CSCfi/etsin-finder-search.svg?branch=test)](https://travis-ci.com/CSCfi/etsin-finder-search)
 
 ## Stable branch
-[![Build Status](https://travis-ci.org/CSCfi/etsin-finder-search.svg?branch=stable)](https://travis-ci.org/CSCfi/etsin-finder-search)
+[![Build Status](https://travis-ci.com/CSCfi/etsin-finder-search.svg?branch=stable)](https://travis-ci.com/CSCfi/etsin-finder-search)
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository contains code for Etsin Finder Search
+This repository contains code for Etsin Finder Search, which is used for dataset searching functionalities in Etsin. This repository has been develpoed using RabbitMQ and ElasticSearch.
 
 # Build status
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository contains code for Etsin Finder Search, which is used for dataset searching functionalities in Etsin. This repository has been develpoed using RabbitMQ and ElasticSearch.
+This repository contains code for Etsin Finder Search, which is used for dataset searching functionalities in Etsin. This repository has been developed using RabbitMQ and ElasticSearch.
 
 # Build status
 


### PR DESCRIPTION
- The new version of Travis is located at travis-ci.com
- Update of authors, license date
- Travis now located at https://travis-ci.com/github/CSCfi/etsin-finder-search/