### PR TITLE
CSCFAIRADM-582: Handling different ES ports for Docker and Ansible environments

### DIFF
--- a/etsin_finder_search/elastic/service/es_service.py
+++ b/etsin_finder_search/elastic/service/es_service.py
@@ -195,6 +195,9 @@ class ElasticSearchService:
             if settings.get('USE_SSL', False):
                 conf.update({'port': 443, 'use_ssl': True, 'verify_certs': True})
             if settings.get('PORT', False):
-                conf.update({'port': 9201, 'use_ssl': False, 'verify_certs': False})
+                if path.isdir(".dockerenv"):
+                    conf.update({'port': 9201, 'use_ssl': False, 'verify_certs': False})
+                else:
+                    conf.update({'port': 9200})
             return conf
         return {}


### PR DESCRIPTION
Enables running ElasticSearch on the default port (9200) if deployed with Ansible, otherwise 9201 (for Docker)